### PR TITLE
Add flake8 support to tox

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md

--- a/tox.ini
+++ b/tox.ini
@@ -2,4 +2,6 @@
 envlist = py3
 
 [testenv]
+deps = flake8
 commands = python -m unittest discover -v
+           flake8


### PR DESCRIPTION
I also added the `README.md` file to the `MANIFEST.in` file. This was so that the setup.py file could find it while building the package using tox.